### PR TITLE
Add support for arrays of hashes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ source "https://rubygems.org"
 group :test do
   gem 'rspec'
   gem 'simplecov'
+  gem 'byebug'
 end
 
 gemspec

--- a/lib/yamlcon/yamlcon.rb
+++ b/lib/yamlcon/yamlcon.rb
@@ -14,10 +14,17 @@ module YAMLCon
   end
 
   def self.hash_to_struct(hash)
+    return hash unless hash.is_a? Hash
     dotted = OpenStruct.new hash
-    hash.each do |k, v| 
-      dotted[k] = hash_to_struct(v) if v.is_a? Hash
+
+    hash.each do |key, value| 
+      if value.is_a? Hash
+        dotted[key] = hash_to_struct(value) 
+      elsif value.is_a? Array
+        dotted[key] = value.collect {|item| hash_to_struct item }
+      end
     end
+
     dotted
   end
 

--- a/spec/fixtures/config.yml
+++ b/spec/fixtures/config.yml
@@ -17,4 +17,10 @@ glados:
       - "You're not even going the right way"
       - "You haven't escaped, you know."
 
+gels:
+  - color: blue
+    effect: repulsion
+  - color: orange
+    effect: propulsion
+
 "emancipation grill": "yes please"

--- a/spec/yamlcon/yamlcon_spec.rb
+++ b/spec/yamlcon/yamlcon_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe "yamlcon" do
+describe YAMLCon do
 
   let :config do
     YAML.load_config 'spec/fixtures/config.yml'
@@ -30,6 +30,12 @@ describe "yamlcon" do
   it "should load deeply nested options" do
     expect(config.glados.texts.during_escape).to be_kind_of Array
     expect(config.glados.texts.during_escape[0]).to eq "Is anyone there?"
+  end
+
+  it "should load array of key value pairs" do
+    expect(config.gels).to be_kind_of Array
+    expect(config.gels.first).to be_kind_of OpenStruct
+    expect(config.gels.first.color).to eq "blue"
   end
 
   it "should save" do


### PR DESCRIPTION
Before this fix, the below would not convert to `OpenStruct` - it would simply stay a hash, not accessible as dot notation.

```yaml
gels:
  - color: blue
    effect: repulsion
  - color: orange
    effect: propulsion
```
